### PR TITLE
Add docker compose for end-to-end testing

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,0 +1,54 @@
+name: End to End tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: Test
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run test server
+        working-directory: ./test
+        run: docker compose up --build --detach --wait --wait-timeout 30
+      - name: querying http returns redirect
+        run: |
+          output=$(curl -s -o /dev/null -w "%{http_code}" http://localhost)
+          ret="$?"
+          echo "$output"
+          if [ "$ret" -ne 0 ]; then
+            exit "$ret"
+          fi
+          if [ "$output" != "301" ]; then
+            exit 42
+          fi
+      - name: querying acme-challenge returns the key
+        run: |
+          output=$(curl -s http://localhost/.well-known/acme-challenge/abc)
+          ret="$?"
+          echo "$output"
+          if [ "$ret" -ne 0 ]; then
+            exit "$ret"
+          fi
+          if [ "$output" != "abc.MISSING_ACCOUNT_THUMBPRINT" ]; then
+            exit 42
+          fi
+      - name: Copy the SSL key
+        working-directory: ./test
+        run: docker compose cp proxy:/etc/reverse_proxy/data/certs/localhost/fullchain.pem .
+      - name: Querying the https route returns 200
+        working-directory: ./test
+        run: |
+          output=$(curl -s -o /dev/null -w "%{http_code}" --cacert fullchain.pem https://localhost)
+          ret="$?"
+          echo "$output"
+          if [ "$ret" -ne 0 ]; then
+            exit "$ret"
+          fi
+          if [ "$output" != "200" ]; then
+            exit 42
+          fi

--- a/README.md
+++ b/README.md
@@ -91,3 +91,9 @@ So, all of the devops revolves around making this happen. Some hoops to jump thr
 1. You need to start nginx before running the certs, so the cert generation is done as a cron job
 1. acme.sh uses a different cron job to renew the certs, so we need to make sure nginx is running
 1. To proxy_pass the data to the remote host, the DNS records need to be set. However, if you just start the reverse proxy, then the DNS entries aren't there. So we use the `set $variable` nginx trick to get around it
+
+# Testing
+
+1. cd [./test](./test/)
+1. sudo docker compose up --build
+1. curl -k https://localhost

--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ So. that's basically it :)
 
 # Environment variables
 
-- `SKIP_BOOTSTRAP=1` means don't create any config files, or self-signed certs
-- `SKIP_CREATE_CERTS=1` means don't call acme --issue to generate the SSL certificates
-- `SKIP_WRITE_NGINX_CONF=1` means that /etc/reverse_proxy/nginx.conf is not overriden during the config process
-- `DEBUG=1` means add verbose logging (set -x) to figure out what's going wrong
+- `SKIP_BOOTSTRAP=1` - don't create any config files, or self-signed certs
+- `SKIP_CREATE_CERTS=1` - don't call acme --issue to generate the SSL certificates
+- `SKIP_RENEW_CERTS=1` - don't call acme --install-cronjob to renew the certificates
+- `SKIP_WRITE_NGINX_CONF=1` - that /etc/reverse_proxy/nginx.conf is not overriden during the config process
+- `DEBUG=1` - add verbose logging (set -x) to figure out what's going wrong
 
 # Advanced configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
       - 443:443
     networks:
       - www
+    healthcheck:
+      test: ['CMD-SHELL', 'curl -so /dev/null http://localhost/ || exit 1']
+      timeout: 5s
+      interval: 5s
+      retries: 6
 
 volumes:
   reverse-proxy-data:

--- a/init.sh
+++ b/init.sh
@@ -18,8 +18,12 @@ init_fn() {
   cp "$nginx_file" /etc/nginx/conf.d/default.conf || exit 1
   # Add the cron job to create the initial certificates
   (crontab -l; echo "* * * * * /etc/reverse_proxy/create_certs.sh") | sort -u | crontab -
-  # Add the cron job to renew the certificates
-  acme --install-cronjob
+  if [ "${SKIP_RENEW_CERTS:-}" = "1" ]; then
+    echo "Skipping acme --install-cronjob due to SKIP_RENEW_CERTS"
+  else
+    # Add the cron job to renew the certificates
+    acme --install-cronjob
+  fi
 }
 
 (set -u; init_fn) || exit $?

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -7,17 +7,28 @@ services:
       - reverse-proxy-test:/etc/reverse_proxy/data
     environment:
       - SKIP_CREATE_CERTS=1
+      - SKIP_RENEW_CERTS=1
       - DEBUG=1
     ports:
       - 80:80
       - 443:443
     networks:
       - web
+    healthcheck:
+      test: ['CMD-SHELL', 'curl -so /dev/null http://localhost/ || exit 1']
+      timeout: 5s
+      interval: 5s
+      retries: 6
 
   hello:
     image: nginxdemos/hello:plain-text
     networks:
       - web
+    healthcheck:
+      test: ['CMD-SHELL', 'curl -so /dev/null http://localhost/ || exit 1']
+      timeout: 5s
+      interval: 5s
+      retries: 6
 volumes:
   reverse-proxy-test:
 

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  proxy:
+    build:
+      context: ./reverse-proxy
+    volumes:
+      - ./test_config.json:/etc/reverse_proxy/config.json
+      - reverse-proxy-test:/etc/reverse_proxy/data
+    environment:
+      - SKIP_CREATE_CERTS=1
+      - DEBUG=1
+    ports:
+      - 80:80
+      - 443:443
+    networks:
+      - web
+
+  hello:
+    image: nginxdemos/hello:plain-text
+    networks:
+      - web
+volumes:
+  reverse-proxy-test:
+
+networks:
+  web:

--- a/test/reverse-proxy
+++ b/test/reverse-proxy
@@ -1,0 +1,1 @@
+../../reverse-proxy

--- a/test/test_config.json
+++ b/test/test_config.json
@@ -1,0 +1,9 @@
+{
+  "email": "test@example.com",
+  "domains": [
+    {
+      "name": "localhost",
+      "dest": "http://hello:80"
+    }
+  ]
+}


### PR DESCRIPTION
* Adds a /test folder which has a self-contained docker-compose for testing
* Adds SKIP_CREATE_CERTS checks around creating the directory (which requires the email & actually calling acme)
* Sets ACCOUNT_THUMBPRINT to `MISSING_ACCOUNT_THUMBPRINT` if SKIP_CREATE_CERTS is true and it hasn't been created