### PR TITLE
silence warning about http2 directive

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -124,8 +124,8 @@ bootstrap_fn() {
     cat << EOF >> "$data_dir/nginx_generated.conf"
     server {
       server_name $server_name;
-      listen 443 ssl http2;
-      listen [::]:443 ssl http2;
+      listen 443 ssl;
+      listen [::]:443 ssl;
       http2 on;
       ssl_certificate $cert_dir/$domain/fullchain.pem;
       ssl_certificate_key $cert_dir/$domain/key.pem;


### PR DESCRIPTION
`http2 on;` is the only setting needed to turn http2 on.
Fixes the following warnings:
```
proxy-1  | 2024/03/19 06:20:59 [warn] 1#1: the "listen ... http2" directive is deprecated, use the "http2" directive instead in /etc/nginx/conf.d/default.conf:
```